### PR TITLE
Improve performance when using only QR-code reading

### DIFF
--- a/js/webcodecamjs.js
+++ b/js/webcodecamjs.js
@@ -583,7 +583,7 @@ var WebCodeCamJS = function(element) {
             qrcode.sourceCanvas = display;
             initialized = true;
             setEventListeners();
-            DecodeWorker = new Worker(options.decoderWorker);
+            DecodeWorker = options.decodeBarCodeRate > 0 ? new Worker(options.decoderWorker) : { };
             if (options.decodeQRCodeRate || options.decodeBarCodeRate) {
                 setCallBack();
             }


### PR DESCRIPTION
When using only QR-code reading, do not generate DecoderWorker.
(when not using barcode reading, it is not necessary to place DecoderWorker.js)